### PR TITLE
Fix MPS issue in CLI tool

### DIFF
--- a/pcleaner/ctd_interface.py
+++ b/pcleaner/ctd_interface.py
@@ -59,89 +59,52 @@ def model2annotations(
     :return:
     """
 
+
+    # For non-MPS systems, use the original multiprocessing approach
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    num_processes = min(config_detector.concurrent_models, len(img_list))
     if torch.backends.mps.is_available():
-        # When MPS is available, use a thread-based approach similar to the GUI
-        # This should address the MPS resource sharing issues
         device = "mps"
-        print(f"Using MPS device for text detection with threading approach")
+        num_processes = 1  # Multiprocessing breaks the mps backend.
+    print(f"Using device for text detection model: {device}")
+    print(f"Using {num_processes} processes for text detection.")
 
-        # Use single-process with threading model
-        print("Creating TextDetector model with MPS...")
-        model = TextDetector(model_path=str(model_path), input_size=1024, device=device)
-        print(f"Created TextDetector with device={device}, backend={model.backend}")
+    if num_processes > 1:
+        mp.freeze_support()
+        mp.set_start_method("spawn")
 
-        # Process images serially (same as GUI approach)
-        for img_path in tqdm(img_list):
-            try:
-                process_image(
-                    img_path,
-                    model,
+        with mp.Pool(num_processes) as pool:
+            # Distribute the images evenly among the processes.
+            batches = [list() for _ in range(num_processes)]
+            for i, img_path in enumerate(img_list):
+                batches[i % num_processes].append(img_path)
+
+            args = [
+                (
+                    batch,
+                    model_path,
+                    device,
                     save_dir,
                     config_general.input_height_lower_target,
                     config_general.input_height_upper_target,
                 )
-            except Exception as e:
-                print(f"ERROR processing {img_path}: {e}")
-                import traceback
-                traceback.print_exc()
+                for batch in batches
+            ]
 
-        return
+            for _ in tqdm(pool.imap_unordered(process_image_batch, args), total=len(args)):
+                pass  # do nothing, just iterate through the results
+
     else:
-        # For non-MPS systems, use the original multiprocessing approach
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        num_processes = min(config_detector.concurrent_models, len(img_list))
-        print(f"Using device for text detection model: {device}")
-        print(f"Using {num_processes} processes for text detection.")
+        model = TextDetector(model_path=str(model_path), input_size=1024, device=device)
 
-        if num_processes > 1:
-            mp.freeze_support()
-            mp.set_start_method("spawn")
-
-            with mp.Pool(num_processes) as pool:
-                # Distribute the images evenly among the processes.
-                batches = [list() for _ in range(num_processes)]
-                for i, img_path in enumerate(img_list):
-                    batches[i % num_processes].append(img_path)
-
-                args = [
-                    (
-                        batch,
-                        model_path,
-                        device,
-                        save_dir,
-                        config_general.input_height_lower_target,
-                        config_general.input_height_upper_target,
-                    )
-                    for batch in batches
-                ]
-
-                for _ in tqdm(pool.imap_unordered(process_image_batch, args), total=len(args)):
-                    pass  # do nothing, just iterate through the results
-
-        else:
-            # Single-process mode: create a processor and handle things sequentially
-            # For single-process mode:
-            print("DEBUG: Creating TextDetector model")
-            model = TextDetector(
-                model_path=str(model_path), input_size=1024, device=device
+        for index, img_path in enumerate(tqdm(img_list)):
+            process_image(
+                img_path,
+                model,
+                save_dir,
+                config_general.input_height_lower_target,
+                config_general.input_height_upper_target,
             )
-            print(f"DEBUG: Created TextDetector with device={device}, backend={model.backend}")
-
-            for img_path in tqdm(img_list):
-                try:
-                    print(f"DEBUG: Processing image {img_path}")
-                    process_image(
-                        img_path,
-                        model,
-                        save_dir,
-                        config_general.input_height_lower_target,
-                        config_general.input_height_upper_target,
-                    )
-                    print(f"DEBUG: Completed processing {img_path}")
-                except Exception as e:
-                    print(f"ERROR processing {img_path}: {e}")
-                    import traceback
-                    traceback.print_exc()
 
 
 def process_image_batch(args) -> None:

--- a/pcleaner/main.py
+++ b/pcleaner/main.py
@@ -418,6 +418,8 @@ def run_cleaner(
             cli.empty_cache_dir(cache_dir)
         # Get the model file, downloading it if necessary.
         gpu = torch.cuda.is_available() or torch.backends.mps.is_available()
+        if torch.backends.mps.is_available():
+            initialize_ocr_model()
         model_path = config.get_model_path(gpu)
 
         split_images(image_paths, profile, cache_dir)
@@ -782,6 +784,8 @@ def run_ocr(
         cli.empty_cache_dir(cache_dir)
     # Get the model file, downloading it if necessary.
     gpu = torch.cuda.is_available() or torch.backends.mps.is_available()
+    if torch.backends.mps.is_available():
+        initialize_ocr_model()
     model_path = config.get_model_path(gpu)
 
     split_images(image_paths, profile, cache_dir)
@@ -1026,6 +1030,13 @@ def merge_export_splits(
             export_targets.append(merged_export_target)
 
     return export_targets
+
+
+def initialize_ocr_model():
+    # Pre-initialize OCR model to properly set up MPS environment
+    print("Pre-initializing OCR model to set up MPS environment...")
+    ocr.ocr_engines()[cfg.OCREngine.MANGAOCR].initialize_model()
+    print("OCR model initialized for MPS")
 
 
 def handle_merging_ocr_splits(


### PR DESCRIPTION
Fixes #148 

### Problem
Text detection was failing or stalling at 0% when using MPS (Metal Performance Shaders) on macOS with Apple Silicon. 

There seems to be two key issues:
The multiprocessing approach doesn't work well with MPS resources, which aren't properly shared across processes.
The NMS (Non-Maximum Suppression) operation used in text detection isn't implemented for MPS devices.
Meanwhile, the GUI version worked correctly with MPS by using threading instead of multiprocessing.

### Solution

In `ctd_interface.py`:
* Use a threading-based approach when MPS is available (like the GUI does)
* Process images serially with the model on MPS
* Add proper error handling with tracebacks to diagnose issues
* Only use multiprocessing for CPU/CUDA devices where it works correctly

In `main.py`:
* Add a helper function to pre-initialize the OCR model for MPS (like the GUI does)
* Call this function when MPS is available to properly set up the environment

### Testing
Tested on macOS with Apple Silicon (M1/M2/M3) and confirmed that text detection now works with MPS acceleration, significantly improving performance compared to CPU-only mode.

Cleaning
```
(base) ➜  PanelCleaner git:(fix--cli-mps) PYTHONPATH=/Users/krchia/PanelCleaner python pcleaner/main.py clean /Users/krchia/manga-chrome-extension/raws -c -k --debug -o /Users/krchia/manga-chrome-extension/cleaned
2025-03-07 14:44:44.060 | DEBUG    | __main__:main:171 - {'--both': False,
 '--cache-masks': False,
 '--cpu': False,
 '--csv': False,
 '--cuda': False,
 '--debug': True,
 '--extract-text': False,
 '--force': False,
 '--help': False,
 '--hide-analytics': False,
 '--keep-cache': True,
 '--notify': False,
 '--output-path': None,
 '--output_dir': '/Users/krchia/manga-chrome-extension/cleaned',
 '--profile': None,
 '--save-only-cleaned': True,
 '--save-only-mask': False,
 '--save-only-text': False,
 '--separate-inpaint-mask': False,
 '--separate-noise-mask': False,
 '--skip-denoising': False,
 '--skip-inpainting': False,
 '--skip-masking': False,
 '--skip-pre-processing': False,
 '--skip-text-detection': False,
 '--version': False,
 '<image_path>': ['/Users/krchia/manga-chrome-extension/raws'],
 '<profile_name>': None,
 '<profile_path>': None,
 'add': False,
 'all': False,
 'cache': False,
 'clean': True,
 'cleaner': False,
 'clear': False,
 'config': False,
 'delete': False,
 'gui': False,
 'languages': False,
 'list': False,
 'load': False,
 'models': False,
 'new': False,
 'ocr': False,
 'open': False,
 'profile': False,
 'purge-missing': False,
 'repair': False,
 'set-default': False,
 'show': False}
2025-03-07 14:44:44.068 | INFO     | pcleaner.cli_utils:dump_system_info:246 -
---- Starting up ----
2025-03-07 14:44:44.069 | INFO     | pcleaner.cli_utils:dump_system_info:292 -
- Program Information -
Program: Panel Cleaner 2.11.7
Executing from: /Users/krchia/PanelCleaner/pcleaner/main.py
Log file: /Users/krchia/Library/Caches/pcleaner/pcleaner.log
Config file: /Users/krchia/Library/Application Support/pcleaner/pcleanerconfig.ini
Cache directory: /Users/krchia/Library/Caches/pcleaner
- System Information -
Operating System: Darwin 24.2.0
Python Version: 3.12.7 | packaged by Anaconda, Inc. | (main, Oct  4 2024, 08:28:27) [Clang 14.0.6 ]
Architecture: x86_64
CPU Cores: 12
Memory: 32.00 GiB
Swap: 1.00 GiB
GPU: None (CUDA not available)

2025-03-07 14:44:44.541 | DEBUG    | pcleaner.config:load_profile:1361 - Loading profile None...
2025-03-07 14:44:44.541 | DEBUG    | pcleaner.config:load_profile:1368 - Loading builtin default profile
2025-03-07 14:44:44.541 | DEBUG    | __main__:main:256 - Config(locale=None, current_profile=Profile(general=GeneralConfig(notes='', preferred_file_type=None, preferred_mask_file_type='.png', layered_export=<LayeredExport.NONE: 'none'>, input_height_lower_target=1000, input_height_upper_target=4000, split_long_strips=True, preferred_split_height=2000, split_tolerance_margin=500, long_strip_aspect_ratio=0.33, merge_after_split=True, max_threads_export=0), text_detector=TextDetectorConfig(model_path=None, concurrent_models=1), preprocessor=PreprocessorConfig(box_min_size=400, suspicious_box_min_size=40000, box_overlap_threshold=20.0, ocr_enabled=True, ocr_use_tesseract=False, ocr_language=<LanguageCode.detect_box: 'detect_box'>, ocr_engine=<OCREngine.AUTO: 'auto'>, reading_order=<ReadingOrder.AUTO: 'auto'>, ocr_max_size=3000, ocr_blacklist_pattern='[～．ー！？０-９~.!?0-9-]*', ocr_strict_language=False, box_padding_initial=2, box_right_padding_initial=3, box_padding_extended=5, box_right_padding_extended=5, box_reference_padding=20), masker=MaskerConfig(max_threads=0, mask_growth_step_pixels=2, mask_growth_steps=11, min_mask_thickness=4, allow_colored_masks=True, off_white_max_threshold=240, mask_max_standard_deviation=15, mask_improvement_threshold=0.1, mask_selection_fast=False, debug_mask_color=(108, 30, 240, 127)), denoiser=DenoiserConfig(denoising_enabled=True, max_threads=0, noise_min_standard_deviation=0.25, noise_outline_size=5, noise_fade_radius=1, colored_images=False, filter_strength=10, color_filter_strength=10, template_window_size=7, search_window_size=21), inpainter=InpainterConfig(inpainting_enabled=False, inpainting_min_std_dev=15, inpainting_max_mask_radius=6, min_inpainting_radius=7, max_inpainting_radius=20, inpainting_radius_multiplier=0.2, inpainting_isolation_radius=5, inpainting_fade_radius=4)), default_profile=None, saved_profiles={}, profile_editor=None, cache_dir=None, default_torch_model_path=PosixPath('/Users/krchia/Library/Caches/pcleaner/model/comictextdetector.pt'), default_cv2_model_path=PosixPath('/Users/krchia/Library/Caches/pcleaner/model/comictextdetector.pt.onnx'), gui_theme=None, show_oom_warnings=True, pa_remember_action=False, pa_wait_time=5, pa_shutdown_command=None, pa_cancel_on_error=True, pa_last_action=None, pa_custom_commands={})
2025-03-07 14:44:44.542 | DEBUG    | __main__:run_cleaner:376 - Inpainting is disabled in the config, skipping inpainting step.
2025-03-07 14:44:44.542 | DEBUG    | __main__:run_cleaner:391 - Cache directory: /Users/krchia/Library/Caches/pcleaner/cleaner
Found 3 images.
2025-03-07 14:44:44.543 | DEBUG    | __main__:run_cleaner:414 - Image paths:
/Users/krchia/manga-chrome-extension/raws/manga.png
/Users/krchia/manga-chrome-extension/raws/manga3.png
/Users/krchia/manga-chrome-extension/raws/manga2.png
Pre-initializing OCR model to set up MPS environment...
2025-03-07 14:44:44.564 | INFO     | pcleaner.ocr.ocr_mangaocr:__new__:17 - Creating the MangaOcr instance
2025-03-07 14:44:44.564 | INFO     | manga_ocr.ocr:__init__:16 - Loading OCR model from kha-white/manga-ocr-base
2025-03-07 14:44:49.341 | INFO     | manga_ocr.ocr:__init__:25 - Using MPS
2025-03-07 14:44:53.878 | INFO     | manga_ocr.ocr:__init__:35 - OCR ready
OCR model initialized for MPS
Running text detection AI model...
Using MPS device for text detection with threading approach
Creating TextDetector model with MPS...
Created TextDetector with device=mps, backend=torch
  0%|                                                                                                                                    | 0/3 [00:00<?, ?it/s]ERROR processing /Users/krchia/manga-chrome-extension/raws/manga.png: The operator 'torchvision::nms' is not currently implemented for the MPS device. If you want this op to be added in priority during the prototype phase of this feature, please comment on https://github.com/pytorch/pytorch/issues/77764. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS.
Traceback (most recent call last):
  File "/Users/krchia/PanelCleaner/pcleaner/ctd_interface.py", line 76, in model2annotations
    process_image(
  File "/Users/krchia/PanelCleaner/pcleaner/ctd_interface.py", line 198, in process_image
    mask, mask_refined, blk_list = model(
                                   ^^^^^^
  File "/opt/anaconda3/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/krchia/PanelCleaner/pcleaner/comic_text_detector/inference.py", line 179, in __call__
    blks = postprocess_yolo(blks, self.conf_thresh, self.nms_thresh, resize_ratio)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/krchia/PanelCleaner/pcleaner/comic_text_detector/inference.py", line 115, in postprocess_yolo
    det = non_max_suppression(det, conf_thresh, nms_thresh)[0]
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/krchia/PanelCleaner/pcleaner/comic_text_detector/utils/yolov5_utils.py", line 263, in non_max_suppression
    i = torchvision.ops.nms(boxes, scores, iou_thres)  # NMS
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/lib/python3.12/site-packages/torchvision/ops/boxes.py", line 41, in nms
    return torch.ops.torchvision.nms(boxes, scores, iou_threshold)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/lib/python3.12/site-packages/torch/_ops.py", line 755, in __call__
    return self._op(*args, **(kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
NotImplementedError: The operator 'torchvision::nms' is not currently implemented for the MPS device. If you want this op to be added in priority during the prototype phase of this feature, please comment on https://github.com/pytorch/pytorch/issues/77764. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS.
 33%|█████████████████████████████████████████▎                                                                                  | 1/3 [00:01<00:02,  1.41s/it]ERROR processing /Users/krchia/manga-chrome-extension/raws/manga3.png: The operator 'torchvision::nms' is not currently implemented for the MPS device. If you want this op to be added in priority during the prototype phase of this feature, please comment on https://github.com/pytorch/pytorch/issues/77764. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS.
Traceback (most recent call last):
  File "/Users/krchia/PanelCleaner/pcleaner/ctd_interface.py", line 76, in model2annotations
    process_image(
  File "/Users/krchia/PanelCleaner/pcleaner/ctd_interface.py", line 198, in process_image
    mask, mask_refined, blk_list = model(
                                   ^^^^^^
  File "/opt/anaconda3/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/krchia/PanelCleaner/pcleaner/comic_text_detector/inference.py", line 179, in __call__
    blks = postprocess_yolo(blks, self.conf_thresh, self.nms_thresh, resize_ratio)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/krchia/PanelCleaner/pcleaner/comic_text_detector/inference.py", line 115, in postprocess_yolo
    det = non_max_suppression(det, conf_thresh, nms_thresh)[0]
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/krchia/PanelCleaner/pcleaner/comic_text_detector/utils/yolov5_utils.py", line 263, in non_max_suppression
    i = torchvision.ops.nms(boxes, scores, iou_thres)  # NMS
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/lib/python3.12/site-packages/torchvision/ops/boxes.py", line 41, in nms
    return torch.ops.torchvision.nms(boxes, scores, iou_threshold)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/lib/python3.12/site-packages/torch/_ops.py", line 755, in __call__
    return self._op(*args, **(kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
NotImplementedError: The operator 'torchvision::nms' is not currently implemented for the MPS device. If you want this op to be added in priority during the prototype phase of this feature, please comment on https://github.com/pytorch/pytorch/issues/77764. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS.
 67%|██████████████████████████████████████████████████████████████████████████████████▋                                         | 2/3 [00:01<00:00,  1.15it/s]ERROR processing /Users/krchia/manga-chrome-extension/raws/manga2.png: The operator 'torchvision::nms' is not currently implemented for the MPS device. If you want this op to be added in priority during the prototype phase of this feature, please comment on https://github.com/pytorch/pytorch/issues/77764. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS.
Traceback (most recent call last):
  File "/Users/krchia/PanelCleaner/pcleaner/ctd_interface.py", line 76, in model2annotations
    process_image(
  File "/Users/krchia/PanelCleaner/pcleaner/ctd_interface.py", line 198, in process_image
    mask, mask_refined, blk_list = model(
                                   ^^^^^^
  File "/opt/anaconda3/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/krchia/PanelCleaner/pcleaner/comic_text_detector/inference.py", line 179, in __call__
    blks = postprocess_yolo(blks, self.conf_thresh, self.nms_thresh, resize_ratio)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/krchia/PanelCleaner/pcleaner/comic_text_detector/inference.py", line 115, in postprocess_yolo
    det = non_max_suppression(det, conf_thresh, nms_thresh)[0]
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/krchia/PanelCleaner/pcleaner/comic_text_detector/utils/yolov5_utils.py", line 263, in non_max_suppression
    i = torchvision.ops.nms(boxes, scores, iou_thres)  # NMS
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/lib/python3.12/site-packages/torchvision/ops/boxes.py", line 41, in nms
    return torch.ops.torchvision.nms(boxes, scores, iou_threshold)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/lib/python3.12/site-packages/torch/_ops.py", line 755, in __call__
    return self._op(*args, **(kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
NotImplementedError: The operator 'torchvision::nms' is not currently implemented for the MPS device. If you want this op to be added in priority during the prototype phase of this feature, please comment on https://github.com/pytorch/pytorch/issues/77764. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS.
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:02<00:00,  1.27it/s]


Running box data Preprocessor...
  0%|                                                                                                                                   | 0/18 [00:00<?, ?it/s]2025-03-07 14:44:57.922 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/fded2942-d667-4b67-a39a-528ac300d953_manga#mask_data.json
2025-03-07 14:44:57.922 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/717b6b5a-a3e5-4d9e-be32-36573be83f77_manga2#raw.json
2025-03-07 14:44:57.925 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/3c718c74-6538-4125-a53f-b36a205e1af3_manga2#raw.json
2025-03-07 14:44:57.928 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/717b6b5a-a3e5-4d9e-be32-36573be83f77_manga2#mask_data.json
2025-03-07 14:44:57.928 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/823daaed-04ec-4739-9c25-67e4db0f8b6f_manga3#clean.json
2025-03-07 14:44:57.928 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/823daaed-04ec-4739-9c25-67e4db0f8b6f_manga3#mask_data.json
2025-03-07 14:44:57.928 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/3c718c74-6538-4125-a53f-b36a205e1af3_manga2#clean.json
2025-03-07 14:44:57.928 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/6b147d80-7091-4d4a-8bbf-02baa25e309a_manga3#raw.json
 44%|██████████████████████████████████████████████████████▋                                                                    | 8/18 [00:00<00:00, 23.64it/s]2025-03-07 14:44:58.260 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/3c718c74-6538-4125-a53f-b36a205e1af3_manga2#mask_data.json
2025-03-07 14:44:58.261 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/fded2942-d667-4b67-a39a-528ac300d953_manga#raw.json
2025-03-07 14:44:58.263 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/6b147d80-7091-4d4a-8bbf-02baa25e309a_manga3#mask_data.json
2025-03-07 14:44:58.263 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/fded2942-d667-4b67-a39a-528ac300d953_manga#clean.json
2025-03-07 14:44:58.263 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/f538c1c0-954c-4e6f-b1a6-12a5a796bea4_manga#raw.json
2025-03-07 14:44:58.266 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/f538c1c0-954c-4e6f-b1a6-12a5a796bea4_manga#mask_data.json
2025-03-07 14:44:58.266 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/823daaed-04ec-4739-9c25-67e4db0f8b6f_manga3#raw.json
 83%|█████████████████████████████████████████████████████████████████████████████████████████████████████▋                    | 15/18 [00:00<00:00, 24.82it/s]2025-03-07 14:44:58.531 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/f538c1c0-954c-4e6f-b1a6-12a5a796bea4_manga#clean.json
2025-03-07 14:44:58.531 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/6b147d80-7091-4d4a-8bbf-02baa25e309a_manga3#clean.json
2025-03-07 14:44:58.532 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/717b6b5a-a3e5-4d9e-be32-36573be83f77_manga2#clean.json
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 18/18 [00:00<00:00, 29.52it/s]

OCR Analytics
━━━━━━━━━━━━━
Number of boxes: 46 | Number of small boxes: 2 (4%)
Number of removed boxes: 0 (0% total, 0% of small boxes)

Small box sizes:
   0- 500:  0 / 0
 500-1000:  0 / 0
1000-1500:  0 / 0
1500-2000: █████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 0 / 2
2000-2500:  0 / 0
2500-3000:  0 / 0

█ Small boxes | █ Removed boxes


Running Masker...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:09<00:00,  1.56s/it]

Mask Fitment Analytics
━━━━━━━━━━━━━━━━━━━━━━
Total boxes: 46 | Masks succeeded: 40 (87%) | Masks failed: 6
Perfect masks: 14 (35%) | Average border deviation: 2.59

Mask usage by thickness (in pixels):
Mask (4px) : ████████████████████████████████████████████████████████████████████████████████████████████ 0 / 6
Mask (6px) : █████████████████████████████████████████████████████████████ 0 / 4
Mask (8px) : ███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 0 / 8
Mask (10px): ████████████████████████████████████████████████████████████████████████████████████████████ 0 / 6
Mask (12px):  0 / 0
Mask (14px): ██████████████████████████████ 0 / 2
Mask (16px): █████████████████████████████████████████████████████████████ 4 / 4
Mask (18px):  0 / 0
Mask (20px): ██████████████████████████████ 2 / 2
Mask (22px): ██████████████████████████████ 2 / 2
Mask (24px): ██████████████████████████████ 2 / 2
Box mask   : █████████████████████████████████████████████████████████████ 4 / 4
Failed     : ████████████████████████████████████████████████████████████████████████████████████████████ 6

█ Perfect | █ Total | █ Failed


Pages with failures / total:
manga3.png: 2 / 22
manga.png: 4 / 14


Running Denoiser...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:08<00:00,  1.43s/it]

Denoising Analytics
━━━━━━━━━━━━━━━━━━━
Total masks: 46 | Masks denoised: 30 (65%)
Minimum deviation to denoise: 0.25 | Maximum allowed deviation: 15
Standard deviation around masks:

 0.00- 0.01 : ████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 0 / 14
 0.01- 0.12 :  0 / 0
 0.12- 0.40 : █████████████████ 0 / 2
 0.40- 0.96 : ████████████████████████████████████████████████████████████████████ 8 / 8
 0.96- 1.88 : ██████████████████████████████████ 4 / 4
 1.88- 3.24 : ██████████████████████████████████ 4 / 4
 3.24- 5.14 : █████████████████ 2 / 2
 5.14- 7.68 :  0 / 0
 7.68-10.93 : █████████████████ 2 / 2
10.93-15.00 : ██████████████████████████████████ 4 / 4

█ Denoised | █ Total



Exporting results...
2025-03-07 14:45:17.598 | DEBUG    | pcleaner.image_export:discover_viable_outputs:341 - Exporting image manga3.png for outputs: [<Output.denoised_output: 19>]
2025-03-07 14:45:17.600 | DEBUG    | pcleaner.image_export:discover_viable_outputs:341 - Exporting image manga2.png for outputs: [<Output.denoised_output: 19>]
2025-03-07 14:45:17.601 | DEBUG    | pcleaner.image_export:discover_viable_outputs:341 - Exporting image manga.png for outputs: [<Output.denoised_output: 19>]
2025-03-07 14:45:17.602 | DEBUG    | pcleaner.image_export:discover_viable_outputs:341 - Exporting image manga.png for outputs: [<Output.denoised_output: 19>]
2025-03-07 14:45:17.603 | DEBUG    | pcleaner.image_export:discover_viable_outputs:341 - Exporting image manga3.png for outputs: [<Output.denoised_output: 19>]
2025-03-07 14:45:17.604 | DEBUG    | pcleaner.image_export:discover_viable_outputs:341 - Exporting image manga2.png for outputs: [<Output.denoised_output: 19>]
  0%|                                                                                                                                    | 0/6 [00:00<?, ?it/s]2025-03-07 14:45:26.153 | DEBUG    | pcleaner.image_export:save_optimized:81 - Saving image manga3_clean.png with kwargs: {'optimize': True, 'compress_level': 9}
2025-03-07 14:45:26.171 | DEBUG    | pcleaner.image_export:save_optimized:81 - Saving image manga2_clean.png with kwargs: {'optimize': True, 'compress_level': 9}
2025-03-07 14:45:26.199 | DEBUG    | pcleaner.image_export:save_optimized:81 - Saving image manga_clean.png with kwargs: {'optimize': True, 'compress_level': 9}
2025-03-07 14:45:26.270 | DEBUG    | pcleaner.image_export:save_optimized:81 - Saving image manga_clean.png with kwargs: {'optimize': True, 'compress_level': 9}
2025-03-07 14:45:26.357 | DEBUG    | pcleaner.image_export:save_optimized:81 - Saving image manga3_clean.png with kwargs: {'optimize': True, 'compress_level': 9}
2025-03-07 14:45:26.420 | DEBUG    | pcleaner.image_export:save_optimized:81 - Saving image manga2_clean.png with kwargs: {'optimize': True, 'compress_level': 9}
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:09<00:00,  1.54s/it]

Done!

Time elapsed: 42.80 seconds
```

OCR
```
(base) ➜  PanelCleaner git:(fix--cli-mps) PYTORCH_ENABLE_MPS_FALLBACK=1 PYTHONPATH=/Users/krchia/PanelCleaner python pcleaner/main.py ocr /Users/krchia/manga-chrome-extension/raws --output-path=/Users/krchia/manga-chrome-extension/ocr.txt --debug
2025-03-07 14:57:06.291 | DEBUG    | __main__:main:171 - {'--both': False,
 '--cache-masks': False,
 '--cpu': False,
 '--csv': False,
 '--cuda': False,
 '--debug': True,
 '--extract-text': False,
 '--force': False,
 '--help': False,
 '--hide-analytics': False,
 '--keep-cache': False,
 '--notify': False,
 '--output-path': '/Users/krchia/manga-chrome-extension/ocr.txt',
 '--output_dir': None,
 '--profile': None,
 '--save-only-cleaned': False,
 '--save-only-mask': False,
 '--save-only-text': False,
 '--separate-inpaint-mask': False,
 '--separate-noise-mask': False,
 '--skip-denoising': False,
 '--skip-inpainting': False,
 '--skip-masking': False,
 '--skip-pre-processing': False,
 '--skip-text-detection': False,
 '--version': False,
 '<image_path>': ['/Users/krchia/manga-chrome-extension/raws'],
 '<profile_name>': None,
 '<profile_path>': None,
 'add': False,
 'all': False,
 'cache': False,
 'clean': False,
 'cleaner': False,
 'clear': False,
 'config': False,
 'delete': False,
 'gui': False,
 'languages': False,
 'list': False,
 'load': False,
 'models': False,
 'new': False,
 'ocr': True,
 'open': False,
 'profile': False,
 'purge-missing': False,
 'repair': False,
 'set-default': False,
 'show': False}
2025-03-07 14:57:06.300 | INFO     | pcleaner.cli_utils:dump_system_info:246 -
---- Starting up ----
2025-03-07 14:57:06.300 | INFO     | pcleaner.cli_utils:dump_system_info:292 -
- Program Information -
Program: Panel Cleaner 2.11.7
Executing from: /Users/krchia/PanelCleaner/pcleaner/main.py
Log file: /Users/krchia/Library/Caches/pcleaner/pcleaner.log
Config file: /Users/krchia/Library/Application Support/pcleaner/pcleanerconfig.ini
Cache directory: /Users/krchia/Library/Caches/pcleaner
- System Information -
Operating System: Darwin 24.2.0
Python Version: 3.12.7 | packaged by Anaconda, Inc. | (main, Oct  4 2024, 08:28:27) [Clang 14.0.6 ]
Architecture: x86_64
CPU Cores: 12
Memory: 32.00 GiB
Swap: 1.00 GiB
GPU: None (CUDA not available)

2025-03-07 14:57:06.891 | DEBUG    | pcleaner.config:load_profile:1361 - Loading profile None...
2025-03-07 14:57:06.892 | DEBUG    | pcleaner.config:load_profile:1368 - Loading builtin default profile
2025-03-07 14:57:06.953 | DEBUG    | __main__:run_ocr:774 - Cache directory: /Users/krchia/Library/Caches/pcleaner/cleaner
Pre-initializing OCR model to set up MPS environment...
2025-03-07 14:57:06.979 | INFO     | pcleaner.ocr.ocr_mangaocr:__new__:17 - Creating the MangaOcr instance
2025-03-07 14:57:06.980 | INFO     | manga_ocr.ocr:__init__:16 - Loading OCR model from kha-white/manga-ocr-base
2025-03-07 14:57:11.729 | INFO     | manga_ocr.ocr:__init__:25 - Using MPS
2025-03-07 14:57:16.183 | INFO     | manga_ocr.ocr:__init__:35 - OCR ready
OCR model initialized for MPS
Running text detection AI model...
Using MPS device for text detection with threading approach
Creating TextDetector model with MPS...
Created TextDetector with device=mps, backend=torch
  0%|                                                                                                                                                                                                                                                                                                    | 0/3 [00:00<?, ?it/s][W MPSFallback.mm:13] Warning: The operator 'torchvision::nms' is not currently supported on the MPS backend and will fall back to run on the CPU. This may have performance implications. (function operator())
2025-03-07 14:57:19.607 | DEBUG    | pcleaner.ctd_interface:process_image:216 - Saving json file to /Users/krchia/Library/Caches/pcleaner/cleaner/fc3543fc-ad10-448b-919c-013bbb773806_manga#raw.json
 33%|██████████████████████████████████████████████████████████████████████████████████████████████▋                                                                                                                                                                                             | 1/3 [00:01<00:03,  1.79s/it]2025-03-07 14:57:20.277 | DEBUG    | pcleaner.ctd_interface:process_image:216 - Saving json file to /Users/krchia/Library/Caches/pcleaner/cleaner/6eba9e2c-c581-48ec-bffa-9f9474afc912_manga3#raw.json
 67%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▎                                                                                              | 2/3 [00:02<00:01,  1.13s/it]2025-03-07 14:57:20.845 | DEBUG    | pcleaner.ctd_interface:process_image:216 - Saving json file to /Users/krchia/Library/Caches/pcleaner/cleaner/dc752aa4-2ec0-4f86-a166-1e071bf07f93_manga2#raw.json
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:03<00:00,  1.01s/it]


Running box data Pre-Processor...
  0%|                                                                                                                                                                                                                                                                                                    | 0/3 [00:00<?, ?it/s]2025-03-07 14:57:20.954 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/fc3543fc-ad10-448b-919c-013bbb773806_manga#raw.json
2025-03-07 14:57:20.956 | DEBUG    | pcleaner.structures:visualize:276 - Loading included font from /Users/krchia/PanelCleaner/pcleaner/data/LiberationSans-Regular.ttf
 33%|██████████████████████████████████████████████████████████████████████████████████████████████▋                                                                                                                                                                                             | 1/3 [00:04<00:08,  4.31s/it]2025-03-07 14:57:25.263 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/dc752aa4-2ec0-4f86-a166-1e071bf07f93_manga2#raw.json
2025-03-07 14:57:25.264 | DEBUG    | pcleaner.structures:visualize:276 - Loading included font from /Users/krchia/PanelCleaner/pcleaner/data/LiberationSans-Regular.ttf
 67%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▎                                                                                              | 2/3 [00:07<00:03,  3.52s/it]2025-03-07 14:57:28.223 | DEBUG    | pcleaner.preprocessor:prep_json_file:124 - Processing json file: /Users/krchia/Library/Caches/pcleaner/cleaner/6eba9e2c-c581-48ec-bffa-9f9474afc912_manga3#raw.json
2025-03-07 14:57:28.224 | DEBUG    | pcleaner.structures:visualize:276 - Loading included font from /Users/krchia/PanelCleaner/pcleaner/data/LiberationSans-Regular.ttf
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:13<00:00,  4.38s/it]

Detected Text:
manga2.png:
ああァ！！ぎゃああ～～～！！
一瞬の気の迷いで
取り逃がした凶悪犯から
おめェ．．．未来を守れるのか？
砲撃

manga3.png:
何を言ってるんだっ！？
あ二人とも結婚式には呼びますから
．．．〜〜〜っ！！！
先輩ーー！？
ごめんっ
げっ解毒薬！！
どこだ！？
早くっ
探せっ
うま～
――つまりあえて捕まってたってことか

manga.png:
フィア先輩！！
ひん死の末に．．．．．！？
終わりの世界からは
ごめん．．．なさい
雨水龍雨大龍香さんの春秋
ちょっと．．．無茶．．．
しちゃいました．．．
```