### PR TITLE
Use getpass module instead of os module to get the username

### DIFF
--- a/pcleaner/gui/log_parser.py
+++ b/pcleaner/gui/log_parser.py
@@ -1,5 +1,5 @@
+import getpass
 import re
-import os
 from datetime import datetime
 from typing import Sequence
 
@@ -16,7 +16,7 @@ def get_username() -> str:
 
     :return: The username of the current user.
     """
-    return os.getlogin()
+    return getpass.getuser()
 
 
 def censor(text: str) -> str:


### PR DESCRIPTION
When running the pcleaner GUI in WSL2 or other limited environments, clicking "Open Log" results in the following error:

```
2025-06-06 21:49:26.317 | CRITICAL | pcleaner.gui.mainwindow_driver:exception_handler:535 - An uncaught exception was raised.
Traceback (most recent call last):

  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code

  File "/home/ubuntu/PanelCleaner/pcleaner/main.py", line 1090, in <module>
    main()
    └ <function main at 0x7f95ca8756c0>

  File "/home/ubuntu/PanelCleaner/pcleaner/main.py", line 323, in main
    gui.launch(args.image_path, args.debug)
    │   │      │                └ {'--both': False,
    │   │      │                   '--cache-masks': False,
    │   │      │                   '--cpu': False,
    │   │      │                   '--csv': False,
    │   │      │                   '--cuda': False,
    │   │      │                   '--debug': False,
    │   │      │                   '--extract...
    │   │      └ {'--both': False,
    │   │         '--cache-masks': False,
    │   │         '--cpu': False,
    │   │         '--csv': False,
    │   │         '--cuda': False,
    │   │         '--debug': False,
    │   │         '--extract...
    │   └ <function launch at 0x7f944d4fae80>
    └ <module 'pcleaner.gui.launcher' from '/home/ubuntu/PanelCleaner/pcleaner/gui/launcher.py'>

  File "/home/ubuntu/PanelCleaner/pcleaner/gui/launcher.py", line 121, in launch
    sys.exit(app.exec())
    │   │    │   └ <staticmethod(<built-in method exec of Shiboken.ObjectType object at 0xd3ad8f0>)>
    │   │    └ <PySide6.QtWidgets.QApplication(0xd5602a0) at 0x7f944d52cd40>
    │   └ <built-in function exit>
    └ <module 'sys' (built-in)>

> File "/home/ubuntu/PanelCleaner/pcleaner/gui/mainwindow_driver.py", line 967, in open_issue_reporter
    issue_reporter = ird.IssueReporter(self)
                     │   │             └ <pcleaner.gui.mainwindow_driver.MainWindow(0xd5cbb80, name="MainWindow") at 0x7f944d58c900>
                     │   └ <class 'pcleaner.gui.issue_reporter_driver.IssueReporter'>
                     └ <module 'pcleaner.gui.issue_reporter_driver' from '/home/ubuntu/PanelCleaner/pcleaner/gui/issue_reporter_driver.py'>

  File "/home/ubuntu/PanelCleaner/pcleaner/gui/issue_reporter_driver.py", line 41, in __init__
    self.load_logs()
    │    └ <function IssueReporter.load_logs at 0x7f944d77a660>
    └ <pcleaner.gui.issue_reporter_driver.IssueReporter(0xdd53aa0, name="IssueReporter") at 0x7f9447ce1fc0>

  File "/home/ubuntu/PanelCleaner/pcleaner/gui/issue_reporter_driver.py", line 80, in load_logs
    self.sessions = lp.parse_log_file(log_text)
    │               │  │              └ '2025-05-29 21:52:10.277 | INFO     | pcleaner.cli_utils:dump_system_info:246 - \n---- Starting up ----\n2025-05-29 21:52:10....
    │               │  └ <function parse_log_file at 0x7f9451056020>
    │               └ <module 'pcleaner.gui.log_parser' from '/home/ubuntu/PanelCleaner/pcleaner/gui/log_parser.py'>
    └ <pcleaner.gui.issue_reporter_driver.IssueReporter(0xdd53aa0, name="IssueReporter") at 0x7f9447ce1fc0>

  File "/home/ubuntu/PanelCleaner/pcleaner/gui/log_parser.py", line 110, in parse_log_file
    sessions.append(LogSession(session_text))
    │        │      │          └ "2025-06-06 21:49:13.908 | INFO     | pcleaner.cli_utils:dump_system_info:292 - \n- Program Information -\nProgram: Panel Cle...
    │        │      └ <class 'pcleaner.gui.log_parser.LogSession'>
    │        └ <method 'append' of 'list' objects>
    └ []

  File "/home/ubuntu/PanelCleaner/pcleaner/gui/log_parser.py", line 47, in __init__
    self.censor()
    │    └ <function LogSession.censor at 0x7f9451055f80>
    └ <pcleaner.gui.log_parser.LogSession object at 0x7f94442ba840>

  File "/home/ubuntu/PanelCleaner/pcleaner/gui/log_parser.py", line 63, in censor
    self.text = censor(self.text)
    │    │      │      │    └ "2025-06-06 21:49:13.908 | INFO     | pcleaner.cli_utils:dump_system_info:292 - \n- Program Information -\nProgram: Panel Cle...
    │    │      │      └ <pcleaner.gui.log_parser.LogSession object at 0x7f94442ba840>
    │    │      └ <function censor at 0x7f9451055d00>
    │    └ "2025-06-06 21:49:13.908 | INFO     | pcleaner.cli_utils:dump_system_info:292 - \n- Program Information -\nProgram: Panel Cle...
    └ <pcleaner.gui.log_parser.LogSession object at 0x7f94442ba840>

  File "/home/ubuntu/PanelCleaner/pcleaner/gui/log_parser.py", line 30, in censor
    return text.replace(get_username(), "<username>")
           │    │       └ <function get_username at 0x7f9451055c60>
           │    └ <method 'replace' of 'str' objects>
           └ "2025-06-06 21:49:13.908 | INFO     | pcleaner.cli_utils:dump_system_info:292 - \n- Program Information -\nProgram: Panel Cle...

  File "/home/ubuntu/PanelCleaner/pcleaner/gui/log_parser.py", line 19, in get_username
    return os.getlogin()
           │  └ <built-in function getlogin>
           └ <module 'os' (frozen)>

FileNotFoundError: [Errno 2] No such file or directory
Error in sys.excepthook:
Traceback (most recent call last):
  File "/home/ubuntu/PanelCleaner/pcleaner/gui/mainwindow_driver.py", line 535, in exception_handler
    gu.show_exception(
  File "/home/ubuntu/PanelCleaner/pcleaner/gui/gui_utils.py", line 97, in show_exception
    box = ErrorDialog(parent, title, msg)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/PanelCleaner/pcleaner/gui/error_dialog_driver.py", line 45, in __init__
    self.tr('Note: Name "{name}" was hidden').format(name=lp.get_username())
                                                          ^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/PanelCleaner/pcleaner/gui/log_parser.py", line 19, in get_username
    return os.getlogin()
           ^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory

Original exception was:
Traceback (most recent call last):
  File "/home/ubuntu/PanelCleaner/pcleaner/gui/mainwindow_driver.py", line 967, in open_issue_reporter
    issue_reporter = ird.IssueReporter(self)
                     ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/PanelCleaner/pcleaner/gui/issue_reporter_driver.py", line 41, in __init__
    self.load_logs()
  File "/home/ubuntu/PanelCleaner/pcleaner/gui/issue_reporter_driver.py", line 80, in load_logs
    self.sessions = lp.parse_log_file(log_text)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/PanelCleaner/pcleaner/gui/log_parser.py", line 110, in parse_log_file
    sessions.append(LogSession(session_text))
                    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/PanelCleaner/pcleaner/gui/log_parser.py", line 47, in __init__
    self.censor()
  File "/home/ubuntu/PanelCleaner/pcleaner/gui/log_parser.py", line 63, in censor
    self.text = censor(self.text)
                ^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/PanelCleaner/pcleaner/gui/log_parser.py", line 30, in censor
    return text.replace(get_username(), "<username>")
                        ^^^^^^^^^^^^^^
  File "/home/ubuntu/PanelCleaner/pcleaner/gui/log_parser.py", line 19, in get_username
    return os.getlogin()
           ^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory
```

To hide the username in the log, the application attempts to retrieve the current username.
This error occurs because `os.getlogin()` fails to retrieve the username properly.
While this works fine in most environments, it seems to fail in certain restricted environments (in my case, the error occurred in WSL2).


```python
Python 3.12.3 (main, Feb  4 2025, 14:48:35) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.getlogin()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
FileNotFoundError: [Errno 2] No such file or directory
>>> import getpass
>>> getpass.getuser()
'ubuntu'
```

The `os` module fails to retrieve the username in certain environments, but the `getpass` module works correctly.
Therefore, I modified the code to use the `getpass` module to retrieve the username instead.
Since `getpass` is a built-in Python module, no additional dependencies are required.