### PR TITLE
feat: add GUARDED_CLEANER_CACHE env var to override cleaner cache

### DIFF
--- a/pcleaner/config.py
+++ b/pcleaner/config.py
@@ -1,4 +1,5 @@
 import re
+import os
 import sys
 import shutil
 import base64
@@ -1170,8 +1171,15 @@ class Config:
     def get_cleaner_cache_dir(self) -> Path:
         """
         Get the cache directory for cleaner models.
+        Can be overridden with GUARDED_CLEANER_CACHE.
         """
-        path = self.get_cache_dir() / "cleaner"
+        guarded_path = os.getenv("GUARDED_CLEANER_CACHE")
+        
+        if guarded_path and os.path.isabs(guarded_path):
+            path = Path(guarded_path) / "cleaner"
+        else:
+            path = self.get_cache_dir() / "cleaner"
+        
         path.mkdir(parents=True, exist_ok=True)
         return path
 


### PR DESCRIPTION
- Allow the cleaner cache directory to be overridden with the GUARDED_CLEANER_CACHE environment variable.
- Only accepts absolute paths for security reasons. Relative paths are ignored.
- Does not affect model cache or other XDG cache paths.

Closes #188 